### PR TITLE
Disallow `instanceof Array` and autofix.

### DIFF
--- a/index.json
+++ b/index.json
@@ -5,7 +5,8 @@
   "parser": "babel-eslint",
   "plugins": [
     "babel",
-    "json"
+    "json",
+    "mysticatea"
   ],
   "env": {
     "browser": true,
@@ -22,6 +23,7 @@
   "rules": {
     "no-underscore-dangle": "off",
     "no-plusplus": ["error", { "allowForLoopAfterthoughts": true }],
-    "react/no-array-index-key": 0
+    "react/no-array-index-key": 0,
+    "mysticatea/no-instanceof-array": "error"
   }
 }

--- a/package.json
+++ b/package.json
@@ -17,7 +17,8 @@
     "url": "https://github.com/Seidemann-Web/eslint-config-seidemann-react.git"
   },
   "dependencies": {
-    "eslint-config-airbnb": "^15.0.1"
+    "eslint-config-airbnb": "^15.0.1",
+    "eslint-plugin-mysticatea": "^4.2.2"
   },
   "devDependencies": {
     "babel-eslint": "^7.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-seidemann-react",
-  "version": "2.0.3",
+  "version": "2.0.4",
   "description": "Eslint config of Seidemann Web for react based projects.",
   "main": "index.json",
   "license": "MIT",


### PR DESCRIPTION
This makes use of the respective rule implementation from [eslint-plugin-mysticatea](https://github.com/mysticatea/eslint-plugin). This rule with trigger on `error` level whenever code like this is seen:

```js
if (someVariable instanceof Array) {
  // ...
}
```

An autofix is implemented by eslint-plugin-mysticatea as well that will replace the code as follows:

```js
if (Array.isArray(someVariable)) {
  // ...
}
```

Also bumps version to 2.0.4.